### PR TITLE
Data scraper improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,5 @@ dmypy.json
 ._.DS_Store
 **/.DS_Store
 **/._.DS_Store
+
+.vscode

--- a/scraper/GraphQLQuery.py
+++ b/scraper/GraphQLQuery.py
@@ -52,7 +52,7 @@ def writeDB(db, result):
             try:
                 packageJSON = json.loads(packageStr)
             except:
-                pass
+                continue
             if 'dependencies' in packageJSON:
                 # insert applications table only if dependencies exist in package.json
                 hashValue = hash(packageStr)

--- a/scraper/PSQL.py
+++ b/scraper/PSQL.py
@@ -18,7 +18,7 @@ def insertToApplication(db, url, followers, appName, hash):
     cur = db.cursor()
     # Upsert a row into the applications table
     cur.execute(
-        "INSERT INTO applications (url, name, followers, retrieved, hash) VALUES (%s, %s, %s, %s, %s) ON CONFLICT ON CONSTRAINT unique_url_and_hash DO UPDATE SET (url, name, followers, retrieved, hash) = (EXCLUDED.url, EXCLUDED.name, EXCLUDED.followers, EXCLUDED.retrieved, EXCLUDED.hash) RETURNING id;",
+        "INSERT INTO applications (url, name, followers, retrieved, hash) VALUES (%s, %s, %s, %s, %s) ON CONFLICT ON CONSTRAINT unique_url DO UPDATE SET (url, name, followers, retrieved, hash) = (EXCLUDED.url, EXCLUDED.name, EXCLUDED.followers, EXCLUDED.retrieved, EXCLUDED.hash) RETURNING id;",
         (url, appName, followers, datetime.datetime.now(), hash))
     application_id = cur.fetchone()[0]
     return application_id


### PR DESCRIPTION
* Application table uniqueness constraint has been restricted to url
  only, so subsequent runs of the data scraper won't create multiple
  entries for the same repository. This means we can re-run our
  machine learning pipeline with no downtime for the web server.

* Fixed a bug where the scraper would attempt to parse a package.json
  even if it wasn't found.