### PR TITLE
Increase max recommendations per dependency from 2 to 10

### DIFF
--- a/webserver/pkgpkr/webservice/recommender_service.py
+++ b/webserver/pkgpkr/webservice/recommender_service.py
@@ -53,7 +53,7 @@ class RecommenderService:
         cur = db.cursor()
 
         # Get recommendations from our model
-        recs_per_dep = 2
+        recs_per_dep = 10
         recommended = []
         for dependency in dependencies:
 


### PR DESCRIPTION
For example, if your application has 10 dependencies, there could be as many as 10 * 10 = 100 recommendations. In practice, however, there will be far fewer than this (at least for now).