### PR TITLE
Only use the major version of packages for training purposes

### DIFF
--- a/webserver/pkgpkr/webservice/recommender_service.py
+++ b/webserver/pkgpkr/webservice/recommender_service.py
@@ -6,6 +6,7 @@ from io import BytesIO
 
 import psycopg2
 import os
+import re
 
 from pkgpkr.settings import NPM_DEPENDENCY_META_URL
 from pkgpkr.settings import NPM_LAST_MONTH_DOWNLOADS_META_API_URL
@@ -23,6 +24,7 @@ class RecommenderService:
     def __init__(self):
 
         self.reimport_model_from_s3()
+        self.majorVersionRegex = re.compile(r'pkg:npm/.*@\d+')
 
     def reimport_model_from_s3(self):
 
@@ -57,8 +59,14 @@ class RecommenderService:
         recommended = []
         for dependency in dependencies:
 
+            # Strip everything after the major version
+            match = self.majorVersionRegex.search(dependency)
+            if not match:
+                continue
+            packageWithMajorVersion = match.group()
+
             # Get the corresponding ID
-            cur.execute(f"SELECT id FROM packages WHERE name = '{dependency}'")
+            cur.execute(f"SELECT id FROM packages WHERE name = '{packageWithMajorVersion}'")
             result = cur.fetchone()
             if not result:
                 continue


### PR DESCRIPTION
This improves the number of recommendations by at least two-fold.