### PR TITLE
Align footer elements

### DIFF
--- a/webserver/pkgpkr/webservice/templates/webservice/base.html
+++ b/webserver/pkgpkr/webservice/templates/webservice/base.html
@@ -102,7 +102,7 @@
     {% block body %}
     {% endblock %}
     <footer class="footer has-background-black has-text-light">
-      <div class="container">
+      <div class="level">
         <div class="level-left">
           <div class="level-item">
             <p>


### PR DESCRIPTION
Before:

<img width="891" alt="Screen Shot 2020-03-26 at 7 49 24 PM" src="https://user-images.githubusercontent.com/186715/77716331-2899bf00-6f9b-11ea-896c-6b66a0ff26a6.png">

After:

<img width="891" alt="Screen Shot 2020-03-26 at 7 49 15 PM" src="https://user-images.githubusercontent.com/186715/77716316-20418400-6f9b-11ea-826b-6780116b54fb.png">