### PR TITLE
Remove inputs having to do with image deploy, since we aren't doing that

### DIFF
--- a/.github/workflows/deploy_ml_pipeline.yml
+++ b/.github/workflows/deploy_ml_pipeline.yml
@@ -78,6 +78,3 @@ jobs:
       uses: aws-actions/amazon-ecs-deploy-task-definition@v1
       with:
         task-definition: ${{ steps.task-def.outputs.task-definition }}
-        service: pkgpkr-ml
-        cluster: default
-        wait-for-service-stability: true


### PR DESCRIPTION
The image deploy is now handled via a scheduled AWS CloudWatch rule and State Machine, so we don't need the GitHub Action to handle this anymore.