### PR TITLE
Catch exception when GitHub API fails to return results

### DIFF
--- a/pipeline/scraper/GitHubQuery.py
+++ b/pipeline/scraper/GitHubQuery.py
@@ -85,11 +85,15 @@ def runQuery(today):
     lastNode = None
     monthlySearchStr = MonthCalculation.getMonthlySearchStr(today)
     while True:
-        result = runQueryOnce(MAX_NODES_PER_LOOP, monthlySearchStr, lastNode)
-        writeDB(db, result)
-        if len(result['data']['search']['edges']) > 0:
-            lastNode = result['data']['search']['edges'][-1]['cursor']
-        else:
+        try:
+            result = runQueryOnce(MAX_NODES_PER_LOOP, monthlySearchStr, lastNode)
+            writeDB(db, result)
+            if len(result['data']['search']['edges']) > 0:
+                lastNode = result['data']['search']['edges'][-1]['cursor']
+            else:
+                break
+        except:
+            print(f"Could not run query starting at {lastNode} for {monthlySearchStr}")
             break
     
     # tear down database connection


### PR DESCRIPTION
I noticed that our scheduled ML pipeline task on AWS failed to run. On investigation, it appears that the data scraper failed to get a 200 response from the GitHub API, causing it to raise an exception that went uncaught and caused the Docker image to exit with an error code.

This PR catches the exception and handles it more gracefully than before.