### PR TITLE
Update dependencies so pyspark will run

### DIFF
--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -1,3 +1,4 @@
+# Our version of PySpark requires Python 3.7
 FROM python:3.7
 
 ARG DB_USER
@@ -17,6 +18,7 @@ RUN mkdir /code
 WORKDIR /code
 COPY requirements.txt /code/
 
+# Our version of PySpark requires Java 8
 RUN echo "deb http://ftp.us.debian.org/debian sid main" > /etc/apt/sources.list
 RUN apt-get update
 RUN apt-get install openjdk-8-jdk -y

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.7
 
 ARG DB_USER
 ARG DB_HOST
@@ -17,8 +17,9 @@ RUN mkdir /code
 WORKDIR /code
 COPY requirements.txt /code/
 
+RUN echo "deb http://ftp.us.debian.org/debian sid main" > /etc/apt/sources.list
 RUN apt-get update
-RUN apt-get install openjdk-11-jdk -y
+RUN apt-get install openjdk-8-jdk -y
 RUN pip install -r requirements.txt
 
 COPY . /code/

--- a/pipeline/model/generate.py
+++ b/pipeline/model/generate.py
@@ -1,5 +1,4 @@
 import os
-import boto3
 import glob
 import psycopg2
 from pyspark.mllib.linalg.distributed import RowMatrix

--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,3 +1,4 @@
 psycopg2-binary==2.8.4
 requests==2.23.0
 pyspark==2.4.5
+numpy==1.17.2


### PR DESCRIPTION
Turns out pyspark is very picky about its dependencies. This PR reverts from Java 11 to Java 8, Python 3.8 to Python 3.7, etc. so the model will train successfully.