### PR TITLE
SCR-72: Don't set package metadata to None during an upsert operation

### DIFF
--- a/pipeline/scraper/GitHubQuery.py
+++ b/pipeline/scraper/GitHubQuery.py
@@ -70,7 +70,7 @@ def writeDB(db, result):
                                 dependencyStr = 'pkg:npm/' + k + "@" + result.group()
                             else:
                                 continue
-                        package_id = PSQL.insertToPackages(db, dependencyStr, None, None, None)
+                        package_id = PSQL.insertToPackages(db, dependencyStr)
                         PSQL.insertToDependencies(db, str(application_id), str(package_id))
                 except:
                     continue

--- a/pipeline/scraper/NpmQuery.py
+++ b/pipeline/scraper/NpmQuery.py
@@ -62,7 +62,7 @@ def runQuery():
     for result in results:
         print(f"Fetching metadata for {result}")
         metadata = get_package_metadata(result)
-        PSQL.insertToPackages(db, metadata['name'], metadata['downloads_last_month'], metadata['categories'], metadata['modified'])
+        PSQL.updatePackageMetadata(db, metadata['name'], metadata['downloads_last_month'], metadata['categories'], metadata['modified'])
 
         # Commit the changes to the database
         db.commit()

--- a/pipeline/scraper/PSQL.py
+++ b/pipeline/scraper/PSQL.py
@@ -3,10 +3,32 @@ import datetime
 import os
 import re
 
-INSERT_TO_APPLICATION_SQL = "INSERT INTO applications (url, name, followers, retrieved, hash) VALUES (%s, %s, %s, %s, %s) ON CONFLICT ON CONSTRAINT unique_url DO UPDATE SET (url, name, followers, retrieved, hash) = (EXCLUDED.url, EXCLUDED.name, EXCLUDED.followers, EXCLUDED.retrieved, EXCLUDED.hash) RETURNING id;"
-INSERT_TO_PACKAGES_SQL = "INSERT INTO packages (name, retrieved) VALUES (%s, %s) ON CONFLICT(name) DO UPDATE SET (name, retrieved) = (EXCLUDED.name, EXCLUDED.retrieved) RETURNING id;"
-UPDATE_PACKAGE_METADATA_SQL = "UPDATE packages SET downloads_last_month = %s, categories = %s, modified = %s WHERE name = %s;"
-INSERT_TO_DEPENDENCIES_SQL = "INSERT INTO dependencies (application_id, package_id) VALUES (%s, %s) ON CONFLICT DO NOTHING;"
+INSERT_TO_APPLICATION_SQL = """
+    INSERT INTO applications (url, name, followers, retrieved, hash)
+    VALUES (%s, %s, %s, %s, %s)
+    ON CONFLICT ON CONSTRAINT unique_url DO UPDATE
+    SET (url, name, followers, retrieved, hash) = (EXCLUDED.url, EXCLUDED.name, EXCLUDED.followers, EXCLUDED.retrieved, EXCLUDED.hash)
+    RETURNING id;
+    """
+INSERT_TO_PACKAGES_SQL = """
+    INSERT INTO packages (name, retrieved)
+    VALUES (%s, %s)
+    ON CONFLICT(name) DO UPDATE
+    SET (name, retrieved) = (EXCLUDED.name, EXCLUDED.retrieved)
+    RETURNING id;
+    """
+UPDATE_PACKAGE_METADATA_SQL = """
+    UPDATE packages SET
+    downloads_last_month = %s,
+    categories = %s,
+    modified = %s
+    WHERE name = %s;"
+    """
+INSERT_TO_DEPENDENCIES_SQL = """
+    INSERT INTO dependencies (application_id, package_id)
+    VALUES (%s, %s)
+    ON CONFLICT DO NOTHING;
+    """
 
 user = os.environ['DB_USER'] or "postgres"
 password = os.environ['DB_PASSWORD'] or "secret"

--- a/pipeline/scraper/PSQL.py
+++ b/pipeline/scraper/PSQL.py
@@ -22,7 +22,7 @@ UPDATE_PACKAGE_METADATA_SQL = """
     downloads_last_month = %s,
     categories = %s,
     modified = %s
-    WHERE name = %s;"
+    WHERE name = %s;
     """
 INSERT_TO_DEPENDENCIES_SQL = """
     INSERT INTO dependencies (application_id, package_id)

--- a/pipeline/scraper/PSQL.py
+++ b/pipeline/scraper/PSQL.py
@@ -4,7 +4,8 @@ import os
 import re
 
 INSERT_TO_APPLICATION_SQL = "INSERT INTO applications (url, name, followers, retrieved, hash) VALUES (%s, %s, %s, %s, %s) ON CONFLICT ON CONSTRAINT unique_url DO UPDATE SET (url, name, followers, retrieved, hash) = (EXCLUDED.url, EXCLUDED.name, EXCLUDED.followers, EXCLUDED.retrieved, EXCLUDED.hash) RETURNING id;"
-INSERT_TO_PACKAGES_SQL = "INSERT INTO packages (name, downloads_last_month, categories, modified, retrieved) VALUES (%s, %s, %s, %s, %s) ON CONFLICT(name) DO UPDATE SET (name, downloads_last_month, categories, modified) = (EXCLUDED.name, EXCLUDED.downloads_last_month, EXCLUDED.categories, EXCLUDED.modified) RETURNING id;"
+INSERT_TO_PACKAGES_SQL = "INSERT INTO packages (name, retrieved) VALUES (%s, %s) ON CONFLICT(name) DO UPDATE SET (name, retrieved) = (EXCLUDED.name, EXCLUDED.retrieved) RETURNING id;"
+UPDATE_PACKAGE_METADATA_SQL = "UPDATE packages SET downloads_last_month = %s, categories = %s, modified = %s WHERE name = %s;"
 INSERT_TO_DEPENDENCIES_SQL = "INSERT INTO dependencies (application_id, package_id) VALUES (%s, %s) ON CONFLICT DO NOTHING;"
 
 user = os.environ['DB_USER'] or "postgres"
@@ -28,7 +29,15 @@ def insertToApplication(db, url, followers, appName, hash):
     return application_id
 
 
-def insertToPackages(db, name, downloads_last_month, categories, modified):
+def insertToPackages(db, name):
+
+    # Upsert a row into the packages table
+    cur = db.cursor()
+    cur.execute(INSERT_TO_PACKAGES_SQL, (name, datetime.datetime.now()))
+    package_id = cur.fetchone()[0]
+    return package_id
+
+def updatePackageMetadata(db, name, downloads_last_month, categories, modified):
 
     # Reformat the category array to a string literal for PostgreSQL
     cur = db.cursor()
@@ -41,10 +50,8 @@ def insertToPackages(db, name, downloads_last_month, categories, modified):
         # Convert to an array literal for PostgreSQL
         categoryString = str(temp).replace("'", "").replace("[", "{").replace("]", "}")
 
-    cur.execute(INSERT_TO_PACKAGES_SQL, (name, downloads_last_month, categoryString, modified, datetime.datetime.now()))
-    package_id = cur.fetchone()[0]
-    return package_id
-
+    # Update package metadata
+    cur.execute(UPDATE_PACKAGE_METADATA_SQL, (downloads_last_month, categoryString, modified, name))
 
 def insertToDependencies(db, application_id, package_id):
     cur = db.cursor()

--- a/pipeline/scraper/test.py
+++ b/pipeline/scraper/test.py
@@ -40,15 +40,15 @@ class TestMyClass(unittest.TestCase):
             try:
                 json_obj = json.load(result)
                 print(json_obj)
-                self.assertTrue(json_obj is not None)
+                self.assertIsNotNone(json_obj)
             except:
-                self.assertFalse(json_obj is not None)
+                self.assertIsNone(json_obj)
     
 
     @ordered
     def test_connectToDB(self):
         db = PSQL.connectToDB()
-        self.assertTrue(db is not None)
+        self.assertIsNotNone(db)
 
 
     @ordered
@@ -59,13 +59,13 @@ class TestMyClass(unittest.TestCase):
         appName = "pkgpkr"
         myHash = hash(appName)
         id = PSQL.insertToApplication(db,url,followers,appName,myHash)
-        self.assertTrue(type(id) == int)
+        self.assertIsInstance(id, int)
         cur = db.cursor()
         cur.execute(
             "SELECT name FROM applications WHERE id = %s;" % (id)
         )
         application_name = cur.fetchone()[0]
-        self.assertTrue(application_name == appName)
+        self.assertEqual(application_name, appName)
 
 
     @ordered
@@ -73,13 +73,13 @@ class TestMyClass(unittest.TestCase):
         db = PSQL.connectToDB()
         name = "myPkg"
         id = PSQL.insertToPackages(db, name)
-        self.assertTrue(type(id) == int)
+        self.assertIsInstance(id, int)
         cur = db.cursor()
         cur.execute(
             "SELECT name FROM packages WHERE id = %s;" % (id)
         )
         package_name = cur.fetchone()[0]
-        self.assertTrue(package_name == name)
+        self.assertEqual(package_name, name)
 
 
     @ordered
@@ -92,7 +92,7 @@ class TestMyClass(unittest.TestCase):
 
         # Insert package into the table
         id = PSQL.insertToPackages(db, name)
-        self.assertTrue(type(id) == int)
+        self.assertIsInstance(id, int)
 
         # Ensure that the modified field is None
         cur = db.cursor()
@@ -100,7 +100,7 @@ class TestMyClass(unittest.TestCase):
             "SELECT modified FROM packages WHERE id = %s;" % (id)
         )
         modified_date = cur.fetchone()[0]
-        self.assertTrue(modified_date == None)
+        self.assertIsNone(modified_date)
 
         # Update metadata in the table
         PSQL.updatePackageMetadata(db, name, downloads_last_month, categories, modified)
@@ -110,18 +110,18 @@ class TestMyClass(unittest.TestCase):
             "SELECT modified FROM packages WHERE id = %s;" % (id)
         )
         modified_date = cur.fetchone()[0]
-        self.assertTrue(modified_date != None)
+        self.assertIsNotNone(modified_date)
 
         # Upsert the same package into the table again
         id = PSQL.insertToPackages(db, name)
-        self.assertTrue(type(id) == int)
+        self.assertIsInstance(id, int)
 
         # Ensure that the modified field is still not None
         cur.execute(
             "SELECT modified FROM packages WHERE id = %s;" % (id)
         )
         modified_date = cur.fetchone()[0]
-        self.assertTrue(modified_date != None)
+        self.assertIsNotNone(modified_date)
 
 
     @ordered
@@ -141,7 +141,7 @@ class TestMyClass(unittest.TestCase):
             % (application_id, package_id)
         )
         result = cur.fetchall()
-        self.assertTrue(result == [(application_id, package_id)])
+        self.assertEqual(result, [(application_id, package_id)])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Scraping is a two-phase operation: 1) we scrape Package names from GitHub, then 2) we scrape Package metadata (downloads, categories, etc) from npmjs.com.

Both of these phases used the `insertToPackages` method to update the database. However, since the data from GitHub lacks metadata information, we were passing None values to `insertToPackages`, causing packages to temporarily lose metadata until the phase 2 process repopulated them again (about a 4 hour window).

This PR splits the `insertToPackages` method into two. The `insertToPackages` is now only responsible for inserting package names, and used only in phase 1. The new `updatePackageMetadata` method is solely responsible for setting package metadata, and is only used in phase 2. This fixes the problem described above.