### PR TITLE
Let people specify HTTP or HTTPS as part of the DOMAIN_NAME

### DIFF
--- a/webserver/pkgpkr/pkgpkr/settings.py
+++ b/webserver/pkgpkr/pkgpkr/settings.py
@@ -142,7 +142,7 @@ GITHUB_ALLOW_SIGN_UP = 'false'
 
 # Endpoints
 GITHUB_BASE_URL = 'https://github.com'
-APP_GITHUB_CALLBACK_URI = f"http://{os.environ.get('DOMAIN_NAME')}/callback"
+APP_GITHUB_CALLBACK_URI = f"{os.environ.get('DOMAIN_NAME')}/callback"
 GITHUB_OATH_AUTH_PATH = f'{GITHUB_BASE_URL}/login/oauth/authorize?client_id={GITHUB_CLIENT_ID}&' \
     f'allow_signup={GITHUB_ALLOW_SIGN_UP}&redirect_uri={APP_GITHUB_CALLBACK_URI}&scope={GITHUB_SCOPE}'
 GITHUB_OATH_ACCESS_TOKEN_PATH = f'{GITHUB_BASE_URL}/login/oauth/access_token'


### PR DESCRIPTION
I've enabled HTTPS on our AWS load balancer (HTTP now directs to HTTPS as well).

This means we now need to specify HTTP or HTTPS as part of the `DOMAIN_NAME` variable (e.g. https://pkgpkr.com), otherwise we can't use HTTP for local development and HTTPS for production.

—

At the moment, you can browse the site at https://pkgpkr.com, but when you try to login, GitHub attempts to redirect to https://pkgpkr.com/callback and fails because HTTP is hardcoded into our Django config.

<img width="1552" alt="Screen Shot 2020-04-04 at 9 53 34 AM" src="https://user-images.githubusercontent.com/186715/78456780-8fce0800-765a-11ea-9bc9-e7c4b229e69f.png">
