### PR TITLE
Add the source packages to which the similarity scores apply

### DIFF
--- a/webserver/pkgpkr/static/main.js
+++ b/webserver/pkgpkr/static/main.js
@@ -22,7 +22,7 @@ $(document).ready( function () {
     });
 
     $('#categoryName').keyup( function() {
-        table.column(1).search($(this).val()).draw();
+        table.column(3).search($(this).val()).draw();
     });
 
     $('#recommendationFilter').keyup( function() {

--- a/webserver/pkgpkr/webservice/templates/webservice/recommendations.html
+++ b/webserver/pkgpkr/webservice/templates/webservice/recommendations.html
@@ -29,17 +29,20 @@
         <table class="display-data-tables">
           <thead>
             <tr>
-              <th>Name</th>
+              <th>Package</th>
+              <th>Recommendation</th>
+              <th>Score</th>
               <th>Category</th>
               <th>Downloads</th>
-              <th>Rate</th>
               <th id="version-date-header">Version Date</th>
             </tr>
           </thead>
           <tbody>
             {% for recommendation in recommendations %}
               <tr>
-                <td><a target="_blank" href="{{ recommendation.url }}">{{ recommendation.name }}</td>
+                <td>{{ recommendation.package }}</td>
+                <td><a target="_blank" href="{{ recommendation.url }}">{{ recommendation.recommendation }}</td>
+                <td>{{ recommendation.similarity }}</td>
                 <td>
                   {% for keyword in recommendation.keywords %}
                   <div class="buttons" style="margin-bottom: 0; display:inline-block;">
@@ -48,11 +51,10 @@
                   {% endfor %}
                 </td>
                 <td>{{ recommendation.average_downloads }}</td>
-                <td>{{ recommendation.rate }}</td>
                 <td>{{ recommendation.date }}</td>
               </tr>
             {% endfor %}
-          </<tbody>
+          <tbody>
         </table>
       </div>
     </div>

--- a/webserver/pkgpkr/webservice/templates/webservice/recommendations.html
+++ b/webserver/pkgpkr/webservice/templates/webservice/recommendations.html
@@ -8,8 +8,12 @@
 <section class="section">
   <div class="container">
     <div class="content is-medium">
-      <h2>RECOMMENDATIONS for `{{ repository_name }}`</h2>
-      <br>
+      <h2>Package recommendations for {{ repository_name }}</h2>
+      <p>
+        This tool recommends packages that frequently appear alongside the packages
+        in {{ repository_name }}. A score of 10 indicates that the packages are
+        <em>always</em> used together.
+      </p>
       <table>
         <tr>
           <td id="selected-category">Selected Category: </td>

--- a/webserver/pkgpkr/webservice/tests/test_recommender_service.py
+++ b/webserver/pkgpkr/webservice/tests/test_recommender_service.py
@@ -19,12 +19,13 @@ class TestRecommenderService(TestCase):
 
     def test_get_recommendation_content(self):
         for recommendation in self.recommendations:
-            self.assertCountEqual({'name', 'url', 'average_downloads', 'keywords', 'date', 'rate'},
+            self.assertCountEqual({'package', 'recommendation', 'url', 'similarity', 'average_downloads', 'keywords', 'date'},
                                   recommendation.keys())
 
-            self.assertIsNotNone(recommendation['name'])
+            self.assertIsNotNone(recommendation['package'])
+            self.assertIsNotNone(recommendation['recommendation'])
             self.assertIsNotNone(recommendation['url'])
+            self.assertIsNotNone(recommendation['similarity'])
             self.assertIsNotNone(recommendation['average_downloads'])
             # TODO this not always passing
             # self.assertIsNotNone(recommendation['date'])
-            self.assertIsNotNone(recommendation['rate'])

--- a/webserver/pkgpkr/webservice/tests/tests.py
+++ b/webserver/pkgpkr/webservice/tests/tests.py
@@ -65,7 +65,7 @@ class LoginTest(LiveServerTestCase):
         self.assertEqual("Recommendations", self.driver.title)
 
         # Category border
-        category_order_ele = self.driver.find_element_by_xpath("//*[@id='DataTables_Table_0']/thead/tr/th[2]")
+        category_order_ele = self.driver.find_element_by_xpath("//*[@id='DataTables_Table_0']/thead/tr/th[4]")
 
         # Click it twice to make sure the first recommendation has at least one category
         category_order_ele.click()
@@ -73,7 +73,7 @@ class LoginTest(LiveServerTestCase):
 
         # The first category
         first_category_ele = self.driver.find_element_by_xpath(
-            "//*[@id='DataTables_Table_0']/tbody/tr[1]/td[2]/div[1]/button")
+            "//*[@id='DataTables_Table_0']/tbody/tr[1]/td[4]/div[1]/button")
         first_category_ele.click()
 
         # Clear button
@@ -86,7 +86,7 @@ class LoginTest(LiveServerTestCase):
         search_ele.clear()
 
         # The first element from the recommendation list
-        first_recommendation_ele = self.driver.find_element_by_xpath("//*[@id='DataTables_Table_0']/tbody/tr/td[1]/a")
+        first_recommendation_ele = self.driver.find_element_by_xpath("//*[@id='DataTables_Table_0']/tbody/tr/td[2]/a")
         first_recommendation_ele.click()
 
         # Logout button


### PR DESCRIPTION
One of the pieces of feedback we got from our Milestone 2 presentation is that people don't understand the similarity score. The similarity score represents the propensity for two packages to appear in the same package.json file together, but because we're only showing one package (the recommendation) it's not clear what package it is supposed to be similar to.

To address this, we're now showing the package that originated each recommendation, making it clearer what the similarity score is measuring.

Before:

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/186715/79052105-e605f280-7be8-11ea-82d8-fc3abbced840.png">

After:

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/186715/79034289-b5cb3f00-7b69-11ea-9ad0-a438612fecbe.png">
