### PR TITLE
Catch another exception case in the pypi query library

### DIFF
--- a/pipeline/scraper/pypi.py
+++ b/pipeline/scraper/pypi.py
@@ -75,12 +75,17 @@ def get_package_metadata(dependency):
         for item in json_result['info']['classifiers']:
             if "Topic :: " in item:
                 entry['categories'].insert(-1, item.replace("Topic :: ", ""))
-    except KeyError:
+    except KeyError as exc:
+        print(f"Could not fetch categories for {dependency_name}: {exc}")
         entry['categories'] = []
 
     try:
         entry['modified'] = json_result['urls'][0]['upload_time_iso_8601']
-    except KeyError:
+    except KeyError as exc:
+        print(f"Could not fetch modified date for {dependency_name}: {exc}")
+        entry['modified'] = None
+    except IndexError as exc:
+        print(f"Could not fetch modified date for {dependency_name}: {exc}")
         entry['modified'] = None
     print(f"pypi entry: {entry}")
     return entry

--- a/pipeline/train_model.py
+++ b/pipeline/train_model.py
@@ -25,8 +25,8 @@ def main():
     assert PORT, "DB_PORT not set"
 
     # Connect to the database
-    database = psycopg2.connect(CONN_STRING)
-    cursor = database.cursor()
+    db_handle = psycopg2.connect(CONN_STRING)
+    cursor = db_handle.cursor()
 
     # ML pipeline
     scores = model.get_similarity_dataframe(cursor)
@@ -37,9 +37,9 @@ def main():
     database.package_table_postprocessing(cursor)
 
     # Commit changes and close the database connection
-    database.commit()
+    db_handle.commit()
     cursor.close()
-    database.close()
+    db_handle.close()
 
 if __name__ == "__main__":
    main()


### PR DESCRIPTION
Saw this exception kill a run of the pypi metadata query script. Catching it now and printing a message when an exception is triggered.

```
/usr/local/lib/python3.7/site-packages/requirements/parser.py:44: UserWarning: Private repos not supported. Skipping.
  warnings.warn('Private repos not supported. Skipping.')
Traceback (most recent call last):
  File "run_scraper.py", line 40, in <module>
    main()
  File "run_scraper.py", line 37, in main
    pypi.run_query()
  File "/code/scraper/pypi.py", line 30, in run_query
    metadata = get_package_metadata(result)
  File "/code/scraper/pypi.py", line 82, in get_package_metadata
    entry['modified'] = json_result['urls'][0]['upload_time_iso_8601']
IndexError: list index out of range
```