### PR TITLE
api support for recommendations

### DIFF
--- a/webserver/pkgpkr/pkgpkr/settings.py
+++ b/webserver/pkgpkr/pkgpkr/settings.py
@@ -163,3 +163,5 @@ PYTHON_DEPENDENCY_FNAME = 'requirements.txt'
 
 SUPPORTED_LANGUAGES = {JAVASCRIPT: {'dependencies_file': JAVASCRIPT_DEPENDENCY_FNAME, 'prefix': 'pkg:npm/'},
                        PYTHON: {'dependencies_file': PYTHON_DEPENDENCY_FNAME, 'prefix': 'pkg:pypi/'}}
+
+DEFAULT_MAX_RECOMMENDATIONS=10000

--- a/webserver/pkgpkr/webservice/github_util.py
+++ b/webserver/pkgpkr/webservice/github_util.py
@@ -232,6 +232,7 @@ def parse_dependencies(dependencies_string, language, is_from_github=False):
     Take a stringified package.json file and extract its dependencies
     :param dependencies_string: A stringified package.json object
     :param language: Language for which dependencies are for
+    :param is_from_github: Indicates if dependencies came for GitHub API (or manual/api call)
     :return:
     """
 

--- a/webserver/pkgpkr/webservice/tests/test_github_utils.py
+++ b/webserver/pkgpkr/webservice/tests/test_github_utils.py
@@ -159,7 +159,9 @@ class TestGithubUtil(TestCase):
         """
         for language, language_attributes in SUPPORTED_LANGUAGES.items():
             # Get dependencies
-            dependencies = parse_dependencies(self.language_to_sampe_file_map[language], language)
+            dependencies = parse_dependencies(dependencies_string=self.language_to_sampe_file_map[language],
+                                              language=language,
+                                              is_from_github=True)
 
             # Assure at least 5 predictions
             self.assertGreaterEqual(len(dependencies), 5)

--- a/webserver/pkgpkr/webservice/tests/test_views.py
+++ b/webserver/pkgpkr/webservice/tests/test_views.py
@@ -231,7 +231,7 @@ class SimpleTest(TestCase):
         self.assertion_helper_for_recom_service_api(post_data, 500, 'Language not supported')
 
         # Issue with language missing
-        post_data = {"language": None, "dependencies": {"lodash": "v4.17.15"}}
+        post_data = {"language": None, "dependencies": {"lodash": "4.17.15"}}
         self.assertion_helper_for_recom_service_api(post_data, 500, 'Error casting language to lower()')
 
         # Issue with empty dependencies for Javascript
@@ -252,7 +252,7 @@ class SimpleTest(TestCase):
 
         # Proper Javascript
         post_data = {"language": "Javascript",
-                     "dependencies": {"lodash": "v4.17.15", "react": "16.13.1",
+                     "dependencies": {"lodash": "4.17.15", "react": "16.13.1",
                                       "express": "4.17.1", "moment": "2.24.0"}}
 
         response = self.assertion_helper_for_recom_service_api(post_data, 200, 'recommended_dependencies')
@@ -269,7 +269,7 @@ class SimpleTest(TestCase):
 
         # Limited Javascript
         post_data = {"language": "Javascript",
-                     "dependencies": {"lodash": "v4.17.15", "react": "16.13.1",
+                     "dependencies": {"lodash": "4.17.15", "react": "16.13.1",
                                       "express": "4.17.1", "moment": "2.24.0"},
                      "max_recommendations": 10}
 

--- a/webserver/pkgpkr/webservice/tests/test_views.py
+++ b/webserver/pkgpkr/webservice/tests/test_views.py
@@ -227,7 +227,7 @@ class SimpleTest(TestCase):
         self.assertion_helper_for_recom_service_api(post_data, 500, 'Required JSON key')
 
         # Issue with language value
-        post_data = {"language": "NOT SUPPORTED VALUE", "dependencies": {"lodash": "v4.17.15"}}
+        post_data = {"language": "NOT SUPPORTED VALUE", "dependencies": {}}
         self.assertion_helper_for_recom_service_api(post_data, 500, 'Language not supported')
 
         # Issue with language missing

--- a/webserver/pkgpkr/webservice/urls.py
+++ b/webserver/pkgpkr/webservice/urls.py
@@ -14,5 +14,6 @@ urlpatterns = [
     path("logout", views.logout, name="logout"),
     path("repositories", views.repositories, name="repositories"),
     path("repositories/<str:name>", views.recommendations, name="recommendations"),
-    path("recommendations/<str:name>", views.recommendations_json, name="recommendations_json")
+    path("recommendations/<str:name>", views.recommendations_json, name="recommendations_json"),
+    path("api/recommendations", views.recommendations_service_api, name="recommendations_service_api")
 ]


### PR DESCRIPTION
### API recommendation fetching

To call use Postman or curl

Method: POST
Endpoint: `api/recommendations`

#### Javascript payload
```
{"language": "javascript",
"dependencies" : {"lodash": "v4.17.15","react": "16.13.1",
"express": "4.17.1", "moment": "2.24.0" },
	"max_recommendations":10
}
```

#### Python payload
```
{"language": "Python",
"dependencies" : ["Django==2.1.2", "requests>=2.23.0", "tensorflow==2.1.0"],
	"max_recommendations":10
}
```

[x]  Code Commented
[x]  Unit tests added and updated