### PR TITLE
Lighten links in the PkgPkr Score modal tooltips

### DIFF
--- a/webserver/pkgpkr/static/styles.css
+++ b/webserver/pkgpkr/static/styles.css
@@ -201,6 +201,15 @@ body {
   font-size: 14px;
 }
 
+.tooltip .tooltiptext a {
+  color: #cccccc;
+  text-decoration: underline;
+}
+
+.tooltip .tooltiptext a:hover {
+  color: #ffffff;
+}
+
 .tooltip .tooltiptext::after {
   content: "";
   position: absolute;


### PR DESCRIPTION
This PR makes links in tooltips easier to read.

Before:

<img width="393" alt="Screen Shot 2020-05-05 at 8 00 32 PM" src="https://user-images.githubusercontent.com/186715/81135245-1dc43980-8f0c-11ea-9b58-a156d1ade5cd.png">

After:

<img width="385" alt="Screen Shot 2020-05-05 at 8 05 53 PM" src="https://user-images.githubusercontent.com/186715/81135247-23218400-8f0c-11ea-85cd-65c8b59586bb.png">
