### PR TITLE
Add external link affordance to docs link since it opens in a new tab

### DIFF
--- a/webserver/pkgpkr/static/styles.css
+++ b/webserver/pkgpkr/static/styles.css
@@ -500,3 +500,8 @@ body {
 table.dataTable tbody td {
   vertical-align: center;
 }
+
+.fa-external-link-alt {
+  opacity: 0.8;
+  font-size: 0.8em;
+}

--- a/webserver/pkgpkr/webservice/templates/webservice/base.html
+++ b/webserver/pkgpkr/webservice/templates/webservice/base.html
@@ -59,7 +59,7 @@
 
               <a class="navbar-item" target="_blank" href="https://pkgpkr.github.io/Package-Picker/">
                 <i class="fas fa-file-alt"></i>
-                <p class="text-icon">Document</p>
+                <p class="text-icon">Docs <i class="fas fa-external-link-alt"></i></p>
               </a>
 
               {% if request.session.github_token %}


### PR DESCRIPTION
Also rename "Document" to "Docs" for brevity.

Before:

<img width="527" alt="Screen Shot 2020-05-05 at 8 14 25 PM" src="https://user-images.githubusercontent.com/186715/81135457-1cdfd780-8f0d-11ea-96de-9c314923bcc6.png">
After:

<img width="500" alt="Screen Shot 2020-05-05 at 8 13 00 PM" src="https://user-images.githubusercontent.com/186715/81135452-19e4e700-8f0d-11ea-844d-cbc9edbafe61.png">
