### PR TITLE
Fix spelling on the landing page

### DIFF
--- a/webserver/pkgpkr/webservice/templates/webservice/index.html
+++ b/webserver/pkgpkr/webservice/templates/webservice/index.html
@@ -16,7 +16,7 @@
                       {% csrf_token %}
                         <div class="field">
                             <label class="label">Add one dependency per line</label>
-                            <label class="label">(You can copy them from your package.json or requirment.txt file!)</label>
+                            <label class="label">(You can copy them from your package.json or requirements.txt file!)</label>
                             <div class="control">
                                 <div id="pick-div-head">
                                     <p>Pick</p>


### PR DESCRIPTION
requirment.txt → requirements.txt

Before:

<img width="536" alt="Screen Shot 2020-05-05 at 8 16 58 PM" src="https://user-images.githubusercontent.com/186715/81135581-9d9ed380-8f0d-11ea-83bc-bc1d7371b6aa.png">

After:

<img width="557" alt="Screen Shot 2020-05-05 at 8 17 20 PM" src="https://user-images.githubusercontent.com/186715/81135576-9a0b4c80-8f0d-11ea-84b2-75e2928e0d63.png">
