### PR TITLE
Don't use the shorthand version of our project name in the docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,12 +3,11 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to pkgpkr's documentation!
-==================================
+Package Picker documentation contents
+=====================================
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
 
    README.md
    setup.md


### PR DESCRIPTION
Before:
<img width="764" alt="Screen Shot 2020-05-05 at 8 25 23 PM" src="https://user-images.githubusercontent.com/186715/81136561-c83e5b80-8f10-11ea-8fe2-6313a0fbefd5.png">

After:
<img width="582" alt="Screen Shot 2020-05-05 at 8 39 33 PM" src="https://user-images.githubusercontent.com/186715/81136567-cb394c00-8f10-11ea-96fd-66513f125b77.png">
