### PR TITLE
Fix scheduled run of ml pipeline

### DIFF
--- a/.github/workflows/deploy_pipeline.yml
+++ b/.github/workflows/deploy_pipeline.yml
@@ -30,10 +30,6 @@ on:
     paths:
       - 'pipeline/**'
       - '.github/workflows/deploy_pipeline.yml'
-  pull_request: # REMOVE BEFORE MERGE
-    paths:
-      - 'pipeline/**'
-      - '.github/workflows/deploy_pipeline.yml'
 
 name: Pipeline Deploy
 

--- a/.github/workflows/deploy_pipeline.yml
+++ b/.github/workflows/deploy_pipeline.yml
@@ -30,6 +30,10 @@ on:
     paths:
       - 'pipeline/**'
       - '.github/workflows/deploy_pipeline.yml'
+  pull_request: # REMOVE BEFORE MERGE
+    paths:
+      - 'pipeline/**'
+      - '.github/workflows/deploy_pipeline.yml'
 
 name: Pipeline Deploy
 

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -26,5 +26,5 @@ WORKDIR /code
 COPY . /code/
 RUN pip3 install -r requirements.txt
 
-CMD python3.7 run_scraper.py && spark-submit --driver-class-path=postgresql-42.2.11.jar --jars=postgresql-42.2.11.jar --driver-memory 12g train_model.py
+CMD python3.7 run_scraper.py && spark-submit --driver-class-path=postgresql-42.2.11.jar --jars=postgresql-42.2.11.jar --driver-memory 15g train_model.py
 

--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -7,7 +7,6 @@ pypistats==0.11.0
 requirements-parser==0.2.0
 # GitHub Action python does not have this default package
 datetime==4.3
-condastats==0.1.3
 pytest==4.6.9
 coverage==5.1
 pytest-cov==2.8.1

--- a/pipeline/run_scraper.py
+++ b/pipeline/run_scraper.py
@@ -7,7 +7,6 @@ import os
 from scraper.github import run_query
 import scraper.npm as npm
 import scraper.pypi as pypi
-import scraper.conda as conda
 
 
 def main():
@@ -35,6 +34,5 @@ def main():
 
     # Fetch package metadata from pypi.org
     pypi.run_query()
-    # conda_query.run_query()
 
 main()

--- a/pipeline/scraper/github.py
+++ b/pipeline/scraper/github.py
@@ -117,7 +117,7 @@ def run_query(today, language='JavaScript'):
                 last_node = result['data']['search']['edges'][-1]['cursor']
             else:
                 break
-        except (ValueError, TypeError) as exc:
+        except (ValueError, TypeError, KeyError) as exc:
             # pylint: disable=line-too-long
             print(f"Could not run query starting at {last_node} for {daily_search_str}: {exc}: {result}")
             break

--- a/pipeline/task-definition-ecs.json
+++ b/pipeline/task-definition-ecs.json
@@ -25,7 +25,7 @@
   }
 ]
 ,
-  "memory": "2048",
+  "memory": "16384",
   "family": "pkgpkr-ml-task-definition",
   "requiresCompatibilities": [
     "FARGATE"

--- a/pipeline/task-definition-ecs.json
+++ b/pipeline/task-definition-ecs.json
@@ -31,5 +31,5 @@
     "FARGATE"
   ],
   "networkMode": "awsvpc",
-  "cpu": "1024"
+  "cpu": "2048"
 }

--- a/pipeline/task-definition-ecs.json
+++ b/pipeline/task-definition-ecs.json
@@ -17,8 +17,8 @@
         "containerPort": 80
       }
     ],
-    "cpu": 1024,
-    "memoryReservation": 2048,
+    "cpu": 2048,
+    "memoryReservation": 16384,
     "image": "nginx:latest",
     "essential": true,
     "name": "nginx"

--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -27,5 +27,5 @@ resource "aws_cloudwatch_event_rule" "run_ml_pipeline" {
 resource "aws_cloudwatch_event_target" "run_ml_pipeline" {
   rule = aws_cloudwatch_event_rule.run_ml_pipeline.name
   arn = aws_sfn_state_machine.run_ml_pipeline.id
-  role_arn = aws_iam_role.run_ml_pipeline.arn
+  role_arn = aws_iam_role.invoke_step_function.arn
 }

--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -20,7 +20,7 @@ resource "aws_cloudwatch_log_stream" "web" {
 resource "aws_cloudwatch_event_rule" "run_ml_pipeline" {
   role_arn = aws_iam_role.invoke_step_function.arn
   description = "Run the pkgpkr ML Pipeline every week"
-  schedule_expression = "rate(7 days)"
+  schedule_expression = "rate(1 day)"
 }
 
 // Event target which glues our CloudWatch rule to our State Machine

--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -19,7 +19,7 @@ resource "aws_cloudwatch_log_stream" "web" {
 // Rule to trigger a run of our ML pipeline once per day
 resource "aws_cloudwatch_event_rule" "run_ml_pipeline" {
   role_arn = aws_iam_role.invoke_step_function.arn
-  description = "Run the pkgpkr ML Pipeline every week"
+  description = "Run the pkgpkr ML Pipeline every day"
   schedule_expression = "rate(1 day)"
 }
 

--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -19,8 +19,8 @@ resource "aws_cloudwatch_log_stream" "web" {
 // Rule to trigger a run of our ML pipeline once per day
 resource "aws_cloudwatch_event_rule" "run_ml_pipeline" {
   role_arn = aws_iam_role.invoke_step_function.arn
-  description = "Run the pkgpkr ML Pipeline every day"
-  schedule_expression = "rate(1 day)"
+  description = "Run the pkgpkr ML Pipeline every week"
+  schedule_expression = "rate(7 days)"
 }
 
 // Event target which glues our CloudWatch rule to our State Machine

--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -6,7 +6,7 @@ resource "aws_db_instance" "default" {
   storage_type         = "gp2"
   engine               = "postgres"
   engine_version       = "11.5"
-  instance_class       = "db.t2.small"
+  instance_class       = "db.t2.medium"
   name                 = "pkgpkr"
   username             = var.DB_USER
   password             = var.DB_PASSWORD

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -62,7 +62,7 @@ resource "aws_ecs_task_definition" "pipeline" {
     "FARGATE"
   ]
   network_mode = "awsvpc"
-  cpu = "1024"
+  cpu = "2048"
 }
 
 // Write task definitions to local files for use by GitHub Actions

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -96,7 +96,7 @@ resource "local_file" "pipeline-task-definition" {
     "FARGATE"
   ],
   "networkMode": "awsvpc",
-  "cpu": "1024"
+  "cpu": "2048"
 }
 PATTERN
 }

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -56,7 +56,7 @@ resource "aws_ecs_task_definition" "web" {
 resource "aws_ecs_task_definition" "pipeline" {
   execution_role_arn = aws_iam_role.execute_task.arn
   container_definitions = file("task-definitions/pkgpkr-pipeline-container.json")
-  memory = "2048"
+  memory = "16384"
   family = "pkgpkr-ml-task-definition"
   requires_compatibilities = [
     "FARGATE"

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -90,7 +90,7 @@ resource "local_file" "pipeline-task-definition" {
 {
   "executionRoleArn": "${aws_iam_role.execute_task.arn}",
   "containerDefinitions": ${file("task-definitions/pkgpkr-pipeline-container.json")},
-  "memory": "2048",
+  "memory": "16384",
   "family": "pkgpkr-ml-task-definition",
   "requiresCompatibilities": [
     "FARGATE"

--- a/terraform/task-definitions/pkgpkr-pipeline-container.json
+++ b/terraform/task-definitions/pkgpkr-pipeline-container.json
@@ -15,7 +15,7 @@
         "containerPort": 80
       }
     ],
-    "cpu": 1024,
+    "cpu": 2048,
     "memoryReservation": 16384,
     "image": "nginx:latest",
     "essential": true,

--- a/terraform/task-definitions/pkgpkr-pipeline-container.json
+++ b/terraform/task-definitions/pkgpkr-pipeline-container.json
@@ -16,7 +16,7 @@
       }
     ],
     "cpu": 1024,
-    "memoryReservation": 2048,
+    "memoryReservation": 16384,
     "image": "nginx:latest",
     "essential": true,
     "name": "nginx"


### PR DESCRIPTION
Changes:

* Increase the compute behind the ML pipeline to 16GB and 2 VCPUs
* Remove last references to Conda in the code (was breaking the pipeline)
* Add another exception case for the GitHub scraper
* Upgrade the database to a t2.medium
* Fix the role assigned to the CloudWatch rule so our daily runs trigger successfully now